### PR TITLE
escape.F remove scalings

### DIFF
--- a/src/Main/escape.F
+++ b/src/Main/escape.F
@@ -280,6 +280,7 @@
               BESC = ZMBAR*BODY(I)
           ELSE
               BESC = ZMBAR*BODY(I)
+              ECRIT = 0.E0
           END IF
           VKM = SQRT(VI2)*VSTAR
 *
@@ -302,18 +303,18 @@
              if(kstart.eq.1.and.first) then
                 first = .false.
                 write (11,*) '        ',
-     &       'TTOT         ','BODY         ',
-     &       'RI           ','VI           ','STEP         ',
-     &       'T[Myr]       ','M[M*]        ','EESC         ',
-     &       'VI[km/s]     ','K*  ','NAME      ',
-     &       'ANGLE PHI    ',' ANGLE THETA ','M1[M*]       ',
-     &       'RADIUS[RSun] ',' LUM[LSun] ','TEFF         ',
-     &       'AGE[Myr]     ',' EPOCH     '
+     &       'TTOT         ','BODY         ','RI           ',
+     &       'VI           ','STEP         ','T[Myr]       ',
+     &       'M[M*]        ','EESC         ','EKIN         ',
+     &       'ECRIT        ','VI[km/s]     ','K*  ',
+     &       'NAME      ','ANGLE PHI    ',' ANGLE THETA ',
+     &       'M1[M*]       ','RADIUS[RSun] ',' LUM[LSun] ',
+     &       'TEFF         ','AGE[Myr]     ',' EPOCH     '
              end if
           WRITE (11,500) TTOT,BODY(I),SQRT(RI2),SQRT(VI2),STEP(I), 
-     &    TESC,BESC,EESC,VKM,KSTARI,NAMEI,(XLIST(2*NCORR+KK),KK=-1,0),
-     &    M1,RM,LUM,TEFF,AGE,EPOCH(I)
- 500  FORMAT(1X,1P,9E13.5,I4,I10,8E13.5)
+     &    TESC,BESC,EESC,ZK,ECRIT,VKM,KSTARI,NAMEI,(XLIST(2*NCORR+KK),
+     &    KK=-1,0),M1,RM,LUM,TEFF,AGE,EPOCH(I)
+ 500  FORMAT(1X,1P,11E13.5,I4,I10,8E13.5)
              call flush(11)
           end if
 *     More output of escaping binaries

--- a/src/Main/escape.F
+++ b/src/Main/escape.F
@@ -272,15 +272,13 @@
 *       Include optional escape output on unit 11.
       IF (KZ(23).EQ.2.OR.KZ(23).EQ.4) THEN
           TESC = TSCALE*TTOT
-          EESC = EI/BODY(I)
-          VB2 = 2.0*ZKIN/ZMASS
+          EESC = EI
 *       Distinguish between tidal field and isolated system (ECRIT at RTIDE).
           IF (KZ(14).GT.0.AND.KZ(14).LE.2) THEN
               ECRIT = -1.5*(TIDAL(1)*ZMASS**2)**0.3333
-              EESC = 2.0*(EESC - ECRIT)/VB2
+              EESC = EESC - ECRIT*BODY(I)
               BESC = ZMBAR*BODY(I)
           ELSE
-              EESC = 2.0*EESC/VB2
               BESC = ZMBAR*BODY(I)
           END IF
           VKM = SQRT(VI2)*VSTAR


### PR DESCRIPTION
commit b043a7f:
Removed VB2 scaling for the energy as well as the BODY(i), thus one get's an EESC output in esc.11 which is more comparable to other energy outputs e.g. in the ADJUST line.

[Example EESC and ETOT plots](https://shad0wfax.de/eesc_comparison.png):
on the left is a plot without this PR, **note the different Y-Axis**: on the left for EESC, on the right ETOT. 
On the right plot there is only one y-axis, and the total escaped energy is shifted by -0.25 for a better comparison with ETOT.

Example runs can be found on kepler in `/home/Tit5/uli.roth/Nbody/TEST_VB2_REMOVED`. The N100k is still running

commit fd0eb1d:
Added ZK and ECRIT as output on esc.11. Though this data can be collected elsewhere, I think it might be helpful to have it at the same location. As this is probably up to discussion, feel free to cherry-pick any commits!