### PR TITLE
Allow argument mismatch

### DIFF
--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -19,7 +19,7 @@ NVCC = @NVCC@
 RESULT = nbody6++@RESULT@
 #FFLAGS = -O3 -fbounds-check -fbacktrace -fno-automatic -fmax-stack-var-size=0 -fPIC -mcmodel=large -Wall
 OMP_FLAGS= -D OMP
-MPI_FLAGS = -fallow-argument-mismatch -D PARALLEL -D PUREMPI
+MPI_FLAGS = -D PARALLEL -D PUREMPI @MPI_FLAGS@
 GPU_FLAGS = -D GPU
 SIMD_FLAGS = -D SIMD
 HDF5_FLAGS = -D H5OUTPUT

--- a/configure
+++ b/configure
@@ -626,6 +626,7 @@ MMAX
 LMAX
 KMAX
 NMAX
+MPI_FLAGS
 EXTRARESULT
 EXTRAOBJ
 EXTRASRC
@@ -2352,7 +2353,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 #AC_CONFIG_MACRO_DIR([./macro])
 # ===========================================================================
-#   http://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+#  https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -2382,33 +2383,12 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 #   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
 #   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
 #
-#   This program is free software: you can redistribute it and/or modify it
-#   under the terms of the GNU General Public License as published by the
-#   Free Software Foundation, either version 3 of the License, or (at your
-#   option) any later version.
-#
-#   This program is distributed in the hope that it will be useful, but
-#   WITHOUT ANY WARRANTY; without even the implied warranty of
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
-#   Public License for more details.
-#
-#   You should have received a copy of the GNU General Public License along
-#   with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-#   As a special exception, the respective Autoconf Macro's copyright owner
-#   gives unlimited permission to copy, distribute and modify the configure
-#   scripts that are the output of Autoconf when processing the Macro. You
-#   need not follow the terms of the GNU General Public License when using
-#   or distributing such scripts, even though portions of the text of the
-#   Macro appear in them. The GNU General Public License (GPL) does govern
-#   all other use of the material that constitutes the Autoconf Macro.
-#
-#   This special exception to the GPL applies to versions of the Autoconf
-#   Macro released by the Autoconf Archive. When you make and distribute a
-#   modified version of the Autoconf Macro, you may extend this special
-#   exception to the GPL to apply to your modified version as well.
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
 
-#serial 3
+#serial 6
 
 
 # AX_FC_CHECK_BOUNDS([ACTION-IF-SUCCESS], [ACTION-IF-FAILURE = FAILURE])
@@ -3238,7 +3218,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_fcflags___fbacktrace" >&5
 $as_echo "$ax_cv_check_fcflags___fbacktrace" >&6; }
-if test x"$ax_cv_check_fcflags___fbacktrace" = xyes; then :
+if test "x$ax_cv_check_fcflags___fbacktrace" = xyes; then :
   FCFLAGS=$FCFLAGS" -fbacktrace"
 else
   :
@@ -3267,7 +3247,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_fcflags___Wall" >&5
 $as_echo "$ax_cv_check_fcflags___Wall" >&6; }
-if test x"$ax_cv_check_fcflags___Wall" = xyes; then :
+if test "x$ax_cv_check_fcflags___Wall" = xyes; then :
   FCFLAGS=$FCFLAGS" -Wall"
 else
   :
@@ -3300,7 +3280,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_fcflags___fPIC" >&5
 $as_echo "$ax_cv_check_fcflags___fPIC" >&6; }
-if test x"$ax_cv_check_fcflags___fPIC" = xyes; then :
+if test "x$ax_cv_check_fcflags___fPIC" = xyes; then :
   FCFLAGS=$FCFLAGS" -fPIC"
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether Fortran compiler accepts -fpic" >&5
@@ -3326,7 +3306,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_fcflags___fpic" >&5
 $as_echo "$ax_cv_check_fcflags___fpic" >&6; }
-if test x"$ax_cv_check_fcflags___fpic" = xyes; then :
+if test "x$ax_cv_check_fcflags___fpic" = xyes; then :
   FCFLAGS=$FCFLAGS" -fpic"
 else
   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
@@ -3364,7 +3344,7 @@ fi
 eval ac_res=\$$as_CACHEVAR
 	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
 $as_echo "$ac_res" >&6; }
-if test x"`eval 'as_val=${'$as_CACHEVAR'};$as_echo "$as_val"'`" = xyes; then :
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"; then :
   FCFLAGS=$FCFLAGS" -mcmodel="$enable_mcmodel
 else
   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
@@ -3372,6 +3352,7 @@ $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "$FC compiler option -mcmodel=$enable_mcmodel is not avaiable
 See \`config.log' for more details" "$LINENO" 5; }
 fi
+
 
 
 
@@ -4423,7 +4404,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cxxflags___march_native" >&5
 $as_echo "$ax_cv_check_cxxflags___march_native" >&6; }
-if test x"$ax_cv_check_cxxflags___march_native" = xyes; then :
+if test "x$ax_cv_check_cxxflags___march_native" = xyes; then :
   CXXFLAGS=$CXXFLAGS" -march=native"
 else
   :
@@ -4460,7 +4441,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cxxflags___fPIC" >&5
 $as_echo "$ax_cv_check_cxxflags___fPIC" >&6; }
-if test x"$ax_cv_check_cxxflags___fPIC" = xyes; then :
+if test "x$ax_cv_check_cxxflags___fPIC" = xyes; then :
   CXXFLAGS=$CXXFLAGS" -fPIC"
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -fpic" >&5
@@ -4492,7 +4473,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cxxflags___fpic" >&5
 $as_echo "$ax_cv_check_cxxflags___fpic" >&6; }
-if test x"$ax_cv_check_cxxflags___fpic" = xyes; then :
+if test "x$ax_cv_check_cxxflags___fpic" = xyes; then :
   CXXFLAGS=$CXXFLAGS" -fpic"
 else
   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
@@ -4536,7 +4517,7 @@ fi
 eval ac_res=\$$as_CACHEVAR
 	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
 $as_echo "$ac_res" >&6; }
-if test x"`eval 'as_val=${'$as_CACHEVAR'};$as_echo "$as_val"'`" = xyes; then :
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"; then :
   CXXFLAGS=$CXXFLAGS" -mcmodel="$enable_mcmodel
 else
   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
@@ -4679,7 +4660,7 @@ fi
 eval ac_res=\$$as_CACHEVAR
 	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
 $as_echo "$ac_res" >&6; }
-if test x"`eval 'as_val=${'$as_CACHEVAR'};$as_echo "$as_val"'`" = xyes; then :
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"; then :
   CXXFLAGS=$CXXFLAGS" -m"$c_simd_check
             RESULT=$RESULT"."$c_simd_check
 	    enable_simd=$c_simd_check
@@ -4815,7 +4796,7 @@ fi
 eval ac_res=\$$as_CACHEVAR
 	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
 $as_echo "$ac_res" >&6; }
-if test x"`eval 'as_val=${'$as_CACHEVAR'};$as_echo "$as_val"'`" = xyes; then :
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"; then :
   CXXFLAGS=$CXXFLAGS" -m"$c_simd_check
                RESULT=$RESULT"."$c_simd_check
 	       enable_simd=$c_simd_check
@@ -4957,7 +4938,7 @@ fi
 eval ac_res=\$$as_CACHEVAR
 	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
 $as_echo "$ac_res" >&6; }
-if test x"`eval 'as_val=${'$as_CACHEVAR'};$as_echo "$as_val"'`" = xyes; then :
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"; then :
   CXXFLAGS=$CXXFLAGS" -m"$enable_simd
                    RESULT=$RESULT"."$enable_simd
 
@@ -5946,6 +5927,43 @@ fi
 # MPI FLAGS
 if test "x$enable_mpi" != xno; then :
   FCFLAGS=$FCFLAGS' $(MPI_FLAGS)'
+      # GCC >= 10 requires -fallow-argument-mismatch flag in MPI
+      # https://gcc.gnu.org/gcc-10/changes.html#fortran
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -fallow-argument-mismatch" >&5
+$as_echo_n "checking whether C++ compiler accepts -fallow-argument-mismatch... " >&6; }
+if ${ax_cv_check_cxxflags___fallow_argument_mismatch+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+  ax_check_save_flags=$CXXFLAGS
+  CXXFLAGS="$CXXFLAGS  -fallow-argument-mismatch"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  ax_cv_check_cxxflags___fallow_argument_mismatch=yes
+else
+  ax_cv_check_cxxflags___fallow_argument_mismatch=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CXXFLAGS=$ax_check_save_flags
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cxxflags___fallow_argument_mismatch" >&5
+$as_echo "$ax_cv_check_cxxflags___fallow_argument_mismatch" >&6; }
+if test "x$ax_cv_check_cxxflags___fallow_argument_mismatch" = xyes; then :
+  MPI_FLAGS=$MPI_FLAGS" -fallow-argument-mismatch"
+else
+  :
+fi
+
       EXTRASRC=$EXTRASRC' $(MPI_FSOURCES)'
       RESULT=$RESULT'.mpi'
 fi
@@ -6020,6 +6038,7 @@ if test "${with_par+set}" = set; then :
 else
   par_size=b16k
 fi
+
 
 if test "x$par_size" == x10m; then :
   NMAX=11048576
@@ -6192,6 +6211,7 @@ if test "x$enable_tools" != xno; then :
 else
   EXTRARESULT=''
 fi
+
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -132,6 +132,7 @@ AX_CHECK_COMPILE_FLAG([-mcmodel=$enable_mcmodel],
    [AC_MSG_FAILURE(
        [$FC compiler option -mcmodel=$enable_mcmodel is not avaiable])])
 
+
 AC_OPENMP
 FCFLAGS=$FCFLAGS' '$OPENMP_FCFLAGS
 
@@ -329,6 +330,9 @@ AS_IF([test "x$enable_gpu" != xno],
 # MPI FLAGS
 AS_IF([test "x$enable_mpi" != xno],
       FCFLAGS=$FCFLAGS' $(MPI_FLAGS)'
+      # GCC >= 10 requires -fallow-argument-mismatch flag in MPI
+      # https://gcc.gnu.org/gcc-10/changes.html#fortran
+      AX_CHECK_COMPILE_FLAG([-fallow-argument-mismatch], [MPI_FLAGS=$MPI_FLAGS" -fallow-argument-mismatch"])
       EXTRASRC=$EXTRASRC' $(MPI_FSOURCES)'
       RESULT=$RESULT'.mpi')
 
@@ -393,7 +397,7 @@ AS_IF([test "x$par_size" == x1m],
        LMAX=600
        MMAX=1024],
       [test "x$par_size" == xb1m],
-      [NMAX=1510720
+      [NMAX=65536
        KMAX=512000
        LMAX=600
        MMAX=2048],
@@ -516,6 +520,7 @@ AC_SUBST([RESULT])
 AC_SUBST([EXTRASRC])
 AC_SUBST([EXTRAOBJ])
 AC_SUBST([EXTRARESULT])
+AC_SUBST([MPI_FLAGS])
 
 AC_SUBST([NMAX])
 AC_SUBST([KMAX])

--- a/configure.ac
+++ b/configure.ac
@@ -391,14 +391,44 @@ AC_ARG_WITH([par],
      [par_size=$withval],
      [par_size=b16k])
 
-AS_IF([test "x$par_size" == x1m],
+AS_IF([test "x$par_size" == x10m],
+      [NMAX=11048576
+       KMAX=131072
+       LMAX=600
+       MMAX=1024],
+      [test "x$par_size" == xb10m],
+      [NMAX=15107200
+       KMAX=5120000
+       LMAX=600
+       MMAX=2048],
+      [test "x$par_size" == x8m],
+      [NMAX=8388608
+       KMAX=131072
+       LMAX=600
+       MMAX=1024],
+      [test "x$par_size" == xb8m],
+      [NMAX=6291456
+       KMAX=2097152
+       LMAX=600
+       MMAX=2048],
+      [test "x$par_size" == x4m],
+      [NMAX=4194304
+       KMAX=131072
+       LMAX=600
+       MMAX=1024],
+      [test "x$par_size" == xb4m],
+      [NMAX=15107200
+       KMAX=1048576
+       LMAX=600
+       MMAX=2048],
+      [test "x$par_size" == x1m],
       [NMAX=1048576
-       KMAX=65536
+       KMAX=131072
        LMAX=600
        MMAX=1024],
       [test "x$par_size" == xb1m],
-      [NMAX=65536
-       KMAX=512000
+      [NMAX=1572864
+       KMAX=524288
        LMAX=600
        MMAX=2048],
       [test "x$par_size" == x512k],

--- a/macro/ax_check_compile_flag.m4
+++ b/macro/ax_check_compile_flag.m4
@@ -1,0 +1,53 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS

--- a/macro/ax_fc_check_bounds.m4
+++ b/macro/ax_fc_check_bounds.m4
@@ -1,0 +1,79 @@
+# AX_FC_CHECK_BOUNDS([ACTION-IF-SUCCESS], [ACTION-IF-FAILURE = FAILURE])
+# ----------------------------------------------------------------------
+# Look for a compiler flag to turn on array bounds checking for the
+# Fortran (FC) compiler, and adds it to FCFLAGS.  Call
+# ACTION-IF-SUCCESS (defaults to nothing) if successful (i.e. can
+# compile code using new extension) and ACTION-IF-FAILURE (defaults to
+# failing with an error message) if not.  (Defined via DEFUN_ONCE to
+# prevent flag from being added to FCFLAGS multiple times.)
+#
+# The known flags are:
+# -fcheck=all, -fbounds-check: gfortran
+#     -fbounds-check: g77, g95
+# -CB, -check bounds: Intel compiler (icc, ecc, ifort)
+#                 -C: Sun/Oracle compiler (f95)
+#        -C, -qcheck: IBM compiler (xlf)
+#           -Mbounds: Portland Group compiler
+#       -C ,-Mbounds: Cray
+#  -C, -check_bounds: SGI compiler
+# -check_bounds, +check=all: HP Fortran
+#        -C, -Rb -Rc: Absoft (-Rb: array boundaries, -Rc: array conformance)
+# --chk e,s -chk (e,s): Lahey
+#          -C -C=all: NAGWare
+# -C, -ffortran-bounds-check: PathScale pathf90
+#                 -C: f2c
+#            -BOunds: Open Watcom
+AC_DEFUN([AX_FC_CHECK_BOUNDS],
+[AC_LANG_PUSH([Fortran])dnl
+AC_CACHE_CHECK([for Fortran flag to enable array-bounds checking],
+               [ac_cv_fc_check_bounds],
+[ac_cv_fc_check_bounds=unknown
+ac_fc_check_bounds_FCFLAGS_save=$FCFLAGS
+for ac_flag in -fcheck=bounds -fbounds-check -check_bounds -Mbounds -qcheck \
+               '-check bounds' +check=all --check '-Rb -Rc' -CB -C=all -C \
+               -ffortran-bounds-check "--chk e,s" "-chk e -chk s" -bounds
+do
+  FCFLAGS="$ac_fc_check_bounds_FCFLAGS_save $ac_flag"
+  # We should be able to link a correct program.
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+    [AC_LINK_IFELSE([[
+      subroutine sub(a)
+      integer a(:)
+      a(8) = 0
+      end subroutine
+
+      program main
+      integer a(1:7)
+      interface
+         subroutine sub(a)
+         integer a(:)
+         end subroutine
+      end interface
+
+      call sub(a)
+      end program]],
+       [# If we can run the program, require failure at run time.
+       # In cross-compiling mode, we rely on the compiler not accepting
+       # unknown options.
+       AS_IF([test "$cross_compiling" = yes],
+         [ac_cv_fc_check_bounds=$ac_flag; break],
+	   [AS_IF([_AC_DO_TOKENS(./conftest$ac_exeext)],
+	        [],
+		     [ac_cv_fc_check_bounds=$ac_flag; break])])])])
+done
+rm -f conftest$ac_exeext conftest.err conftest.$ac_objext conftest.$ac_ext \
+  core *.core core.conftest.*
+FCFLAGS=$ac_fc_check_bounds_FCFLAGS_save
+])
+if test "x$ac_cv_fc_check_bounds" = xunknown; then
+  m4_default([$2],
+             [AC_MSG_ERROR([no Fortran flag for bounds checking found], 77)])
+else
+  if test "x$ac_cv_fc_check_bounds" != xnone; then
+    FCFLAGS="$FCFLAGS $ac_cv_fc_check_bounds"
+  fi
+  $1
+fi
+AC_LANG_POP([Fortran])dnl
+])# AC_FC_CHECK_BOUNDS
+


### PR DESCRIPTION
- commit 2dc4d8d: configure script checks if `-fallow-argument-mismatch` is needed. As of now, the flag is added to `MPI_FLAGS` **if** both mpi is enabled (e.g. configured without `--disable-mpi`) **and** gcc versions 10 and above.

- commit e0f4e88: readded macro files `macro/ax_check_compile_flag.m4` and `macro/ax_fc_check_bounds.m4` for simplified future work on the configure script
**Note** The Macros are *not* introduced to change anything, rather introduced to keep everything as it is.
**Note** I've noticed that the `configure` script contains more options for `par_size`s than the `configure.ac` file. This commit also adds the missing `par_size`s  to `configure.ac`, such that `autoconf` generates a more similar `configure` script to the original one.

For some reason autotools now generates `"x$var"` instead of `x"$var"`, which accounts for a few more changes in a couple of lines. I couldn't find any problems in my tests with this version.