### PR TITLE
Fix argument mismatches outside of MPI

### DIFF
--- a/src/Main/intgrt.F
+++ b/src/Main/intgrt.F
@@ -1242,7 +1242,7 @@ c$$$         if(rank.eq.0)ttmov = ttmov +(tt334-tt333)*60.
 *     custom output
       call cputim(ttiout1)
       IF(KZ(46).GT.0.AND.DMOD(TIME,DTOUT).EQ.0) THEN
-         call custom_output(NXTLEN,NXTLST,NXTLIMIT,NGHOSTS,IMINR)
+         call custom_output(NXTLEN,NXTLST,NXTLIMIT,NGHOSTS)
       END IF
       call cputim(ttiout2)
       if(rank.eq.0)ttout = ttout + (ttiout2 - ttiout1)*60.

--- a/src/Main/ksint.f
+++ b/src/Main/ksint.f
@@ -722,6 +722,7 @@ c$$$      print*,rank,'rmax',rmax
       INTEGER RES,KMIN
       REAL*8 SEMI,M1,M2,CLIGHT,ECC,DT,DE(5),TGR,DTX
       REAL*8 ECCNEW,SEMNEW,ECCN,SEMN
+      REAL*8 ttgr1,ttgr2
       LOGICAL LSANE
       include 'timing.h'
 *


### PR DESCRIPTION
commit b788933: ksint.f contains two subroutines. In the first one (`KSINT`) `cputim` is called (line 51) on `tt1` with an `IMPLICIT REAL*8` from `common6.h`. Later on in subroutine `GW_DECISION` `cputim` is called again (line 728) on a variable called `ttgr`, but this time without any IMPLICIT behavior.
On **some** machines this leads to an argument mismatch, as their default behavior is REAL\*4 instead of REAL\*8 from the first subroutine.

commit bf2bc808: Remove `IMINR` from `custom_output` call (line 1245). In `src/Main/custom_output.F` IMINR is not an argument, but introduced in common6.h.
To me it looks like IMINR once was given to custom_output as argument, but at some point it moved to `common6.h`. There is another call to `custom_output` in line 140 without the IMINR argument. Probably the other call in line 1245 was just forgotten.
