### PR TITLE
ksint.f: fix argument mismatch

### DIFF
--- a/src/Main/ksint.f
+++ b/src/Main/ksint.f
@@ -725,6 +725,7 @@ c$$$      print*,rank,'rmax',rmax
       INTEGER RES,KMIN
       REAL*8 SEMI,M1,M2,CLIGHT,ECC,DT,DE(5),TGR,DTX
       REAL*8 ECCNEW,SEMNEW,ECCN,SEMN
+      REAL*8 ttgr1, ttgr2
       LOGICAL LSANE,COMP
       include 'timing.h'
 *


### PR DESCRIPTION
argument mismatch outside of mpi was originally fixed in PR #8 but then unfortunately reintroduced in PR #9.

This error only comes up when using the --disable-mpi flag, as otherwise argument mismatches are ignored. However this leads to the broken checks/pipes. Should fix problems.

Just adds REAL*8 to ttgr1 and ttgr2 (as it was already accepted in #8)