### PR TITLE
Close leaked HDF5 dataspace/property-list/group handles in custom output writers

### DIFF
--- a/src/Main/custom_output_facility.F
+++ b/src/Main/custom_output_facility.F
@@ -30,12 +30,16 @@
       CHARACTER(LEN=64) :: obj_name
       INTEGER*4 :: obj_type, num_objs
       LOGICAL :: file_exists
-      
+      LOGICAL, SAVE :: h5_lib_init = .FALSE.
+
 *       Close any previously opened file (if any)
       IF (h5_file_id .GT. 0) CALL HDF5_CLOSE
 
-*     Initialize FORTRAN interface.
-      CALL h5open_f(ERROR) 
+*     Initialize FORTRAN interface (only once per run).
+      IF (.NOT. h5_lib_init) THEN
+        CALL h5open_f(ERROR)
+        h5_lib_init = .TRUE.
+      ENDIF
 
 *     Create a new file using default properties.
       h5_file_name = h5_fname
@@ -160,6 +164,7 @@
             CALL h5pset_chunk_f(crp_list, 1, data_chunkdims, error)
             CALL h5dcreate_f(group_id, dset_name, H5T_NATIVE_REAL,
      &         dspace_id, dset_id, error, crp_list)
+            CALL h5pclose_f(crp_list, error)
          ENDIF ! finalize == .TRUE.
 
          IF(offset .GT. 1) THEN
@@ -180,6 +185,7 @@ c$$$  15        CONTINUE
             CALL h5dwrite_f(dset_id, H5T_NATIVE_REAL, vec,
      &         data_dims, error)
          ENDIF ! offset > 1
+         CALL h5sclose_f(dspace_id, error)
          IF(finalize .EQV. .TRUE.) CALL h5dclose_f(dset_id, error)
       ELSE ! dset_id > 0
 *     Expand the existing dataset
@@ -211,7 +217,8 @@ c$$$  25      CONTINUE
            CALL h5dwrite_f(dset_id, H5T_NATIVE_REAL, vec,
      &         data_dims, error, memspace_id, dspace_id)
          ENDIF ! offset > 1
-*         CALL h5sclose_f(dspace_id, error)
+         CALL h5sclose_f(memspace_id, error)
+         CALL h5sclose_f(dspace_id, error)
          IF(finalize .EQV. .TRUE.) CALL h5dclose_f(dset_id, error)
       ENDIF ! dset_id == 0
 #endif
@@ -267,6 +274,7 @@ c$$$  25      CONTINUE
             CALL h5pset_chunk_f(crp_list, 1, data_chunkdims, error)
             CALL h5dcreate_f(group_id, dset_name, H5T_NATIVE_INTEGER,
      &         dspace_id, dset_id, error, crp_list)
+            CALL h5pclose_f(crp_list, error)
          ENDIF
 
 
@@ -281,6 +289,7 @@ c$$$  25      CONTINUE
             CALL h5dwrite_f(dset_id, H5T_NATIVE_INTEGER, vec,
      &         data_dims, error)
          ENDIF
+         CALL h5sclose_f(dspace_id, error)
          IF(finalize .EQV. .TRUE.) CALL h5dclose_f(dset_id, error)
       ELSE  ! dset_id > 0
 *     Expand the existing dataset
@@ -309,6 +318,7 @@ c$$$  25      CONTINUE
            CALL h5dwrite_f(dset_id, H5T_NATIVE_INTEGER, vec,
      &         data_dims, error, memspace_id, dspace_id)
          ENDIF ! offset > 1
+         CALL h5sclose_f(memspace_id, error)
          CALL h5sclose_f(dspace_id, error)
          IF(finalize .EQV. .TRUE.) CALL h5dclose_f(dset_id, error)
       ENDIF
@@ -456,14 +466,18 @@ c$$$  25      CONTINUE
       INTEGER*4 :: original_vec_len
       LOGICAL :: finalize
 *
+*       Nothing to write: return before creating/opening the HDF5
+*       group, otherwise it would be left open (leaked) below.
+      IF (N_SINGLE.LE.0) RETURN
+*
 *       CALL INIT if not yet done.
       IF (h5_file_id.eq.0) then
           CALL HDF5_INIT(h5_file_name)
-      END IF 
+      END IF
 *       IF file cannot be initilized, quit the subroutine
       IF (h5_file_id .EQ. 0) RETURN
 
-      
+
       IF (TTOT.GT.h5_current_time) THEN
 *       Needs to create new group
           h5_step = h5_step + 1
@@ -512,8 +526,6 @@ cc          WRITE (h5_step_name, *), h5_step
       ENDIF 
       original_vec_len = 0
       finalize = .TRUE.
-*
-      IF (N_SINGLE.LE.0) RETURN
 *
 *     Write datasets
       CALL HDF5_write_real_vector_as_dset(h5_group_id, '000 Scalars',
@@ -789,10 +801,14 @@ cc          WRITE (h5_step_name, *), h5_step
       INTEGER*4 :: original_vec_len
       LOGICAL :: finalize ! if TRUE, finalize the datasets
 *
+*       Nothing to write: return before creating/opening the HDF5
+*       group, otherwise it would be left open (leaked) below.
+      IF (N_BINARY.LE.0) RETURN
+*
 *       CALL INIT if not yet done.
       IF (h5_file_id.eq.0) then
           CALL HDF5_INIT(h5_file_name)
-      END IF 
+      END IF
 *       IF file cannot be initilized, quit the subroutine
       IF (h5_file_id .EQ. 0) RETURN
 
@@ -851,8 +867,6 @@ cc          WRITE (h5_step_name, *), h5_step
           finalize = .TRUE.
       ENDIF
 
-      IF (N_BINARY.LE.0) RETURN
-      
 *       Write datasets
       CALL HDF5_write_real_vector_as_dset(h5_group_id, '101 Bin cm X1',
      &     B_XC1, N_BINARY, 1, h5_dset_ids(64),
@@ -1307,10 +1321,13 @@ cc          WRITE (h5_step_name, *), h5_step
       LOGICAL :: finalize
 
 C*     Merger
+*       Nothing to write: return before creating/opening the HDF5
+*       group, otherwise it would be left open (leaked) below.
+      IF (N_MERGER.LE.0) RETURN
 *       CALL INIT if not yet done.
       IF (h5_file_id.eq.0) then
           CALL HDF5_INIT(h5_file_name)
-      END IF 
+      END IF
 *       IF file cannot be initilized, quit the subroutine
       IF (h5_file_id .EQ. 0) RETURN
 
@@ -1369,9 +1386,7 @@ cc          WRITE (h5_step_name, *), h5_step
 *    &    'N_MERGER', N_MERGER) ! Write attribute to the group
           original_vec_len = 0
           finalize = .TRUE.
-      ENDIF 
-
-      IF (N_MERGER.LE.0) RETURN
+      ENDIF
 
 *       Write datasets
       CALL HDF5_write_real_vector_as_dset(h5_group_id, '201 Mer XC1',


### PR DESCRIPTION
Fixes #37

## Summary

The HDF5 particle-output writers in `src/Main/custom_output_facility.F` leak resources on every snapshot write, which shows up as steadily growing process memory (RES) over the course of a long-running simulation with HDF5 output enabled.

- `HDF5_write_real_vector_as_dset` / `HDF5_write_integer_vector_as_dset` create a dataspace (`h5screate_simple_f`) and, on the chunked/extensible path, a property list (`h5pcreate_f`) for every dataset write, but never close them. Since `output_single`/`output_binary`/`output_merger` always call these routines with `finalize=.TRUE.`, every particle-property vector written at every snapshot leaks one dataspace handle (plus a property list on the chunked path). Over a long run with many snapshots this accumulates a large number of open HDF5 identifiers.
- `output_single`/`output_binary`/`output_merger` created (or reopened) the current HDF5 step group *before* checking whether there was anything to write (`N_SINGLE`/`N_BINARY`/`N_MERGER` <= 0), and returned early in that case without closing the group. Since binaries/mergers are frequently absent at a given snapshot, this leaked a group handle on essentially every step where there were none.
- `HDF5_INIT` called `h5open_f` (library-wide init) every time a new snapshot file was started instead of once per run.

This PR closes the dataspace/property-list handles right after each write, and moves the "nothing to write" early-return before the HDF5 group is created/opened so no group handle is leaked when there are no binaries/mergers to write that step.

## Local verification

Built locally with `./configure --enable-mcmodel=large --with-par=b1m --disable-gpu --disable-mpi --enable-hdf5` and `make`, then ran the same small-N test input (based on `examples/input_files/N10k_noDat10.inp`) with both the pre-fix and post-fix binaries for an identical number of integration steps:

- Both binaries reproduce bit-identical simulation trajectories (same step count, same `N`, `E`, `DE` at each step), confirming the change has no effect on the physics/output content.
- Output HDF5 files remain valid and readable with `h5py`, with correct per-step attributes (`N_STAR`, `Time`) and dataset shapes/values.
- Peak RSS (`/usr/bin/time -v`) for the fixed binary was consistently lower than the unfixed one for the same number of snapshot writes, consistent with the leaked dataspace/group handles being the source of the growth (the difference matches the expected leaked-handle count reasonably closely).

GPU-specific code paths are untouched by this change.

## Test plan

- [x] `./configure --enable-mcmodel=large --with-par=b1m --disable-gpu --disable-mpi --enable-hdf5 && make` builds cleanly
- [x] Ran a short simulation with HDF5 output enabled (KZ(46)=4) before/after the fix and compared peak RSS and HDF5 output validity
- [x] CI (autotest workflow) — all checks passed (arm64_qemu_1k, gcc9_old_1k, mpi_and_hdf5, new_namelist_input_10k)
