### PR TITLE
fix: correct exponent placement in Eggleton IMF (KZ(20)=3,5)

### DIFF
--- a/src/Main/imf2.f
+++ b/src/Main/imf2.f
@@ -37,7 +37,7 @@ c      DATA  G1,G2,G3,G4  /0.28,1.14,0.010,0.1/
           IF (KZ(20).EQ.2.OR.KZ(20).EQ.4) THEN
               ZM = 0.08 + (G1*XX**G2 + G3*XX**G4)/(1.0 - XX)**0.58
           ELSE IF (KZ(20).EQ.3.OR.KZ(20).EQ.5) THEN
-              ZM = 0.3*XX/(1.0 - XX)**0.55
+              ZM = 0.3*(XX/(1.0 - XX))**0.55
           ELSE IF (KZ(20).EQ.6.OR.KZ(20).EQ.7.OR.KZ(20).EQ.8) THEN
               LM = BODYN
               UM = BODY10


### PR DESCRIPTION
Fixes #26

## Summary

`IMF2` (`src/Main/imf2.f`) generates stellar masses via inverse-transform sampling for several IMF options selected by `KZ(20)`. For `KZ(20).EQ.3.OR.KZ(20).EQ.5`, the manual documents this as "Eggleton-IMF" — it's meant to implement equation (1.17) from P. Eggleton's textbook *Evolutionary Processes in Binary and Multiple Stars* (2006), §1.6 ("A Monte Carlo model"):

```
M_1 = 0.3 * ( X_1 / (1 - X_1) )^0.55
```

The code instead had:

```fortran
ZM = 0.3*XX/(1.0 - XX)**0.55
```

Because `**` binds tighter than `*`/`/` in Fortran, this evaluates as `0.3*XX^1/(1-XX)^0.55` — the exponent is only applied to the denominator, not to the whole ratio. This was reported in #26 with a Python demonstration showing the buggy formula under-produces mass at the low-mass end relative to the book's formula.

This PR is a one-line fix:

```fortran
ZM = 0.3*(XX/(1.0 - XX))**0.55
```

### Provenance of the bug

The buggy line is present verbatim in the very first commit of the original public NBODY6 source release ([nbodyx/Nbody6@0d21d8b](https://github.com/nbodyx/Nbody6/commit/0d21d8b5fa6d6e9e8d02b85a7260225573fd6595), "First commit of NBODY6", 2015-09-18), and has never been touched since NBODY6++GPU/this fork's own earliest history. So this is a long-standing bug inherited from the original NBODY6 code base, not something introduced by NBODY6++GPU or this fork.

## Root-cause verification

- Confirmed the book's exact equation by inspecting the page image attached to #26 (Eggleton 2006, §1.6, eq. 1.17): `M_1 = 0.3*(X_1/(1-X_1))^0.55`.
- Monte Carlo reproduction, both as an idealized NumPy simulation and by compiling a standalone Fortran driver that reuses the project's own `RAN2` generator (`src/Main/ran2.f`), sampling 500k–2M draws and applying the same accept/reject bounds `[BODYN, BODY10]` that `IMF2` actually uses. Both methods agree closely:
  - Within `[BODYN, BODY10] = [0.1, 50.0] Msun`: the buggy formula produces **26% more stars below 0.15 Msun** than the book-correct formula (KS test, p < 0.001), and a lower accept-rate under rejection sampling (72% vs 88%), consistent with the low-mass excess reported in #26.
  - The bulk of the distribution (median, p50) is only mildly shifted; the discrepancy is concentrated near the low-mass cutoff.

## Local verification

Built locally with `./configure --enable-mcmodel=large --with-par=b1m --disable-gpu --disable-mpi --enable-hdf5 && make`, then ran a small N=1000 test (`KZ(20)=3`, based on `examples/input_files/N10k_noDat10.inp`) with both the pre-fix and post-fix binaries (toggling the one-line change and rebuilding in between):

- Both binaries build and run to completion without errors.
- `<MS>` (mean single-star mass) reported by `IMF2` shifts in the expected direction with the fix (0.577 → 0.566 Msun for this N=1000/seed sample), consistent with the larger-N Monte Carlo reproduction above.
- Only the `KZ(20).EQ.3.OR.KZ(20).EQ.5` branch is touched; the `KZ(20)=2,4` (KTG93) and `KZ(20)=6,7,8` (Kroupa 2001 + brown dwarfs) branches, and the separate Eggleton binary mass-ratio correlation (`(m1/m2)' = (m1/m2)^0.4`), are unaffected.

Note (unrelated, not addressed by this PR): reproducing this required `ulimit -s unlimited`, because `IMF2` allocates two `NMAX`-sized automatic arrays (`COPYX`, `COPYV`) on the stack, which overflows the default 8 MB stack on this machine regardless of `KZ(20)`. This is a pre-existing issue unrelated to the Eggleton-IMF formula and out of scope here; flagging it for a possible separate fix.

## Test plan

- [x] `./configure --enable-mcmodel=large --with-par=b1m --disable-gpu --disable-mpi --enable-hdf5 && make` builds cleanly
- [x] Ran a short simulation with `KZ(20)=3` before/after the fix and compared the reported mean single-star mass
- [x] Verified the fix only affects the `KZ(20)=3,5` branch by reading the full routine
- [x] Independent review pass (Codex) of the diff: approved, no issues found
- [x] CI (autotest workflow) — all checks passed (arm64_qemu_1k, gcc9_old_1k, mpi_and_hdf5, new_namelist_input_10k)

